### PR TITLE
fix: recovery not success,but update replica status ok

### DIFF
--- a/src/com/netbric/s5/conductor/RecoveryManager.java
+++ b/src/com/netbric/s5/conductor/RecoveryManager.java
@@ -105,7 +105,7 @@ public class RecoveryManager {
 					break;
 				} else if(status.status == BackgroundTaskManager.TaskStatus.FAILED){
 					logger.error("Failed recovery replica:0x{} on store:{} complete failed", Long.toHexString(r.replica_id), r.store_ip);
-					recovery_ok = 0;
+					recovery_ok = -1;
 					break;
 				}
 			}

--- a/src/com/netbric/s5/conductor/RecoveryManager.java
+++ b/src/com/netbric/s5/conductor/RecoveryManager.java
@@ -105,7 +105,7 @@ public class RecoveryManager {
 					break;
 				} else if(status.status == BackgroundTaskManager.TaskStatus.FAILED){
 					logger.error("Failed recovery replica:0x{} on store:{} complete failed", Long.toHexString(r.replica_id), r.store_ip);
-					recovery_ok = -1;
+					recovery_ok = 0;
 					break;
 				}
 			}
@@ -125,8 +125,11 @@ public class RecoveryManager {
 					logger.error("end_recovery on slave node:{} failed, reason:{}", r.store_ip, reply.reason);
 					throw new Exception(reply.reason);
 				}
-				logger.info("SET_REPLICA_STATUS_OK Set replica:0x{} to OK status, recovery succeeded", Long.toHexString(r.replica_id));
-				S5Database.getInstance().sql("update t_replica set status='OK' where id=?", r.replica_id).execute();
+
+				if (recovery_ok == 1) {
+				        logger.info("SET_REPLICA_STATUS_OK Set replica:0x{} to OK status, recovery succeeded", Long.toHexString(r.replica_id));
+				        S5Database.getInstance().sql("update t_replica set status='OK' where id=?", r.replica_id).execute();
+				}
 			}
 
 			task.progress += 100/total;


### PR DESCRIPTION
集群3节点，一个volume 100G，2个shard，2副本，其中每个shard都有一个副本在192.168.61.143，kill 192.168.61.143上pfs进程之后，又重新启动该pfs进程，执行./pfcli recovery_volume -v test_v

192.168.61.143的日志报错：
[ERRO 2025-09-30 11:44:01.651]Peer IP for store_id:1 not found(/home/flyslice/yangxiao/cocalele/PureFlash/pfs/src/pf_replicator.cpp:286:get_conn) 
[ERRO 2025-09-30 11:44:01.651]Failed get connection to store:1 for  recovery read (/home/flyslice/yangxiao/cocalele/PureFlash/pfs/src/pf_replicator.cpp:207:begin_recovery_read_io) 
[ERRO 2025-09-30 11:44:01.651]recovery single obj entry failed, rc:-5(/home/flyslice/yangxiao/cocalele/PureFlash/pfs/src/pf_flash_store.cpp:2199:recovery_object_series) 
[ERRO 2025-09-30 11:44:01.651]Failed recovery replica:0x4a000001, from:192.168.61.229:2aa3c7d4-d2e9-4aee-ae4a-6b3322a67ff8 => /dev/nvme0n1, at obj_size:67108864(/home/flyslice/yangxiao/cocalele/PureFlash/pfs/src/pf_flash_store.cpp:2208:recovery_object_series) 

[ERRO 2025-09-30 11:44:11.705]Peer IP for store_id:1 not found(/home/flyslice/yangxiao/cocalele/PureFlash/pfs/src/pf_replicator.cpp:286:get_conn) 
[ERRO 2025-09-30 11:44:11.705]Failed get connection to store:1 for  recovery read (/home/flyslice/yangxiao/cocalele/PureFlash/pfs/src/pf_replicator.cpp:207:begin_recovery_read_io) 
[ERRO 2025-09-30 11:44:11.705]recovery single obj entry failed, rc:-5(/home/flyslice/yangxiao/cocalele/PureFlash/pfs/src/pf_flash_store.cpp:2199:recovery_object_series) 
[ERRO 2025-09-30 11:44:11.706]Failed recovery replica:0x4a000011, from:192.168.61.229:ae294cb4-ba8e-453a-9b1d-04ab03b4f693 => /dev/nvme0n1, at obj_size:67108864(/home/flyslice/yangxiao/cocalele/PureFlash/pfs/src/pf_flash_store.cpp:2208:recovery_object_series)


jconductor日志报错：
ERROR com.netbric.s5.conductor.RecoveryManager - Failed recovery replica:0x4a000001 on store:192.168.61.143 complete failed
但是，还有日志显示更改了replica 状态：
INFO com.netbric.s5.conductor.RecoveryManager - SET_REPLICA_STATUS_OK Set replica:0x4a000001 to OK status, recovery succeeded

jconductor日志报错：
ERROR com.netbric.s5.conductor.RecoveryManager - Failed recovery replica:0x4a000011 on store:192.168.61.143 complete failed
但是，还有日志显示更改了replica 状态：
INFO com.netbric.s5.conductor.RecoveryManager - SET_REPLICA_STATUS_OK Set replica:0x4a000011 to OK status, recovery succeeded