### PR TITLE
fix: first shard recovery success, but second shard recovery fail

### DIFF
--- a/src/com/netbric/s5/conductor/RecoveryManager.java
+++ b/src/com/netbric/s5/conductor/RecoveryManager.java
@@ -25,6 +25,7 @@ public class RecoveryManager {
 		long total = S5Database.getInstance().queryLongValue("select count(*) from t_replica where volume_id=? and status != ?",  v.id, Status.OK);
 		List<Shard> illhealthShards = S5Database.getInstance().where("volume_id=? and status != ?", v.id, Status.OK).results(Shard.class);
 		for(Shard s : illhealthShards) {
+			v = Volume.fromId(v.id);
 			recoveryShard(task, v, total, s);
 		}
 		S5Database.getInstance().sql("update t_volume set status=IF((select count(*) from t_shard where status!='OK' and volume_id=?) = 0, 'OK', status)" +


### PR DESCRIPTION
数据恢复的问题：
一个volume 100G，2个shard，2副本，其中每个shard都有一个副本在192.168.61.143，kill 192.168.61.143上pfs进程之后，又重新启动服务，执行./pfcli recovery_volume -v test_v

数据恢复过程中，第一个shard恢复完成之后，会更新volume所有的replica的store上的meta_ver（VolumeHandler.pushMetaverToStore(vol);）

但是，第二行shard恢复的时候，pfconductor仍然会使用之前的meta_ver，导致数据恢复失败：
第二个shard中状态为error的slave replica，store的pfs执行恢复的是对应日志：
[INFO 2025-10-09 21:21:15.294]recovering object (rep_id:0x49000011 offset:68719476736) 1 objects[1] to recover (/home/cocalele/PureFlash/pfs/src/pf_flash_store.cpp:2192:recovery_object_series) 
[INFO 2025-10-09 21:21:15.294]recovering object (rep_id:0x49000011 offset:68719476736 snap: 1) (/home//cocalele/PureFlash/pfs/src/pf_flash_store.cpp:2220:recovery_single_object_entry) 
[INFO 2025-10-09 21:21:25.301]api op:query_task, op=query_task&task_id=2(/home/cocalele/PureFlash/pfs/src/pf_restful_server.cpp:29:handle_api)

第二个shard中状态为OK的primary replica，store的pfs执行恢复的是对应日志： 
[ERRO 2025-10-09 21:21:15.321]Cannot dispatch_io, op:S5_OP_RECOVERY_READ(14), volume:0x49000000 meta_ver:9 diff than client:8(/home/cocalele/PureFlash/pfs/src/pf_dispatcher.cpp:175:dispatch_io) 
[ERRO 2025-10-09 21:21:15.321]Cannot dispatch_io, op:S5_OP_RECOVERY_READ(14), volume:0x49000000 meta_ver:9 diff than client:8(/home/cocalele/PureFlash/pfs/src/pf_dispatcher.cpp:175:dispatch_io) 
[ERRO 2025-10-09 21:21:15.321]Cannot dispatch_io, op:S5_OP_RECOVERY_READ(14), volume:0x49000000 meta_ver:9 diff than client:8(/home/cocalele/PureFlash/pfs/src/pf_dispatcher.cpp:175:dispatch_io) 
[ERRO 2025-10-09 21:21:15.321]Cannot dispatch_io, op:S5_OP_RECOVERY_READ(14), volume:0x49000000 meta_ver:9 diff than client:8(/home/cocalele/PureFlash/pfs/src/pf_dispatcher.cpp:175:dispatch_io)