### PR TITLE
fix: full disk should not be primary replica

### DIFF
--- a/src/com/netbric/s5/conductor/handler/ErrorHandler.java
+++ b/src/com/netbric/s5/conductor/handler/ErrorHandler.java
@@ -71,7 +71,7 @@ public class ErrorHandler {
 			logger.info("{} replicas was set to ERROR state", changed);
 			if(changed > 0) {
 				long primaryIndex = S5Database.getInstance().queryLongValue("select primary_rep_index from t_shard where id=?", shardId);
-				if(primaryIndex == repId) {
+				if (primaryIndex == VolumeIdUtils.replicaIdToIndex(repId)) {
 					S5Database.getInstance().transaction(trans).sql("update t_shard set primary_rep_index=" +
 							"(select replica_index  from t_replica where shard_id=? and status='OK' " +
 								"order by status_time asc, replica_index asc limit 1) " +


### PR DESCRIPTION
写入某个replica的primary replica，该replica对应的disk空间满了，更新了t_volume的status、t_replica的status
但是，并未更新t_shard的primary_rep_index（primary replica index），
导致，客户端重新open volume之后，写入该replica仍然是访问原来primary replica对应的disk，一直失败