### PR TITLE
fix: delete useless infos in database

### DIFF
--- a/src/com/netbric/s5/cluster/ClusterManager.java
+++ b/src/com/netbric/s5/cluster/ClusterManager.java
@@ -220,6 +220,8 @@ public class ClusterManager
 
 					}
 				});
+				Transaction ts = S5Database.getInstance().startTransaction();
+				S5Database.getInstance().transaction(ts).sql("delete from t_tray where store_id=? and device=? and uuid!=?", tr.store_id, tr.device, tr.uuid).execute();
 				if(S5Database.getInstance().sql("select count(*) from t_tray where uuid=?", t).first(long.class) == 0)
 					S5Database.getInstance().insert(tr);
 				else


### PR DESCRIPTION
同样的磁盘，只是格式化，重新部署之后，会产生新的UUID，旧的UUID残留在数据库中，需要删除