### PR TITLE
fix: error sql, query fields is inconsistent with class ReplicaArg

### DIFF
--- a/src/com/netbric/s5/conductor/handler/VolumeHandler.java
+++ b/src/com/netbric/s5/conductor/handler/VolumeHandler.java
@@ -766,7 +766,7 @@ public class VolumeHandler
 			shard.primary_rep_index = dbShard.primary_rep_index;
 			long shardId = dbShard.id;
 
-			shard.replicas = S5Database.getInstance().sql("select r.replica_id as id, r.replica_index as 'index', r.tray_uuid, r.store_id, r.status, r.store_id, r.status, r.rep_ports " +
+			shard.replicas = S5Database.getInstance().sql("select r.replica_id as id, r.replica_index as 'index', r.store_id, r.tray_uuid, r.status, r.rep_ports " +
 					" from v_replica_ext r where r.shard_id=?", shardId)
 					.results(ReplicaArg.class);
 			if (shard.replicas.size() == 0)


### PR DESCRIPTION
查询语句是："select r.replica_id as id, r.replica_index as 'index', r.tray_uuid, r.store_id, r.status, r.store_id, r.status, r.rep_ports " +
					" from v_replica_ext r where r.shard_id=?", shardId)

查询结果：id, index, tray_uuid, store_id, status, store_id, status, rep_portes

但是，	class ReplicaArg的定义如下，查询结果与成员不是一一对应的
public static class ReplicaArg
	{
		public long id;
		public long index;
		public long store_id;
		public String tray_uuid;
		public String status;
		public String rep_ports;
		public String dev_name;
		public ReplicaArg clone()
		{
			ReplicaArg r  = new ReplicaArg();
			r.id = id;
			r.index = index;
			r.store_id = store_id;
			r.tray_uuid = tray_uuid;
			r.status = status;
			r.rep_ports = rep_ports;
			return r;
		}
	};

