### PR TITLE
feature: store id not be changed, but trays infos...be changed, old i…

### DIFF
--- a/src/com/netbric/s5/cluster/ZkHelper.java
+++ b/src/com/netbric/s5/cluster/ZkHelper.java
@@ -85,9 +85,7 @@ public class ZkHelper {
 					children2 = children;
 				}
 			} catch (Exception e) {
-				logger.error("Exception in watching {}, {}", parentPath, e.toString());
-				e.printStackTrace();
-				System.exit(1);
+				logger.error("Error during watch {}, {}", parentPath, e.toString());
 			}
 		}).start();
 	}


### PR DESCRIPTION
feature: store id not be changed, but trays infos...be changed, old infos in zk and db, should be changed or deleted

场景：
store id = 1, 之前的服务器使用该id，启动了pfstore
在zk内保留该store的信息：
[zk: 192.168.61.143:2181(CONNECTED) 7] ls /pureflash/cluster1/stores/1
[alive, mngt_ip, ports, rep_ports, state, trays]
db保留该store的信息：
t_tray、t_port、t_store

后期服务器故障，或者，磁盘故障，数据迁移到其他机器后，
另外一台机器或者原机器进行磁盘格式化（或更换磁盘），继续使用store id = 1，启动pfstore
此时，pfstore对应的配置文件pfs.conf内容与之前已经发生了变化
但是，启动pfstore之后，在zookeeper与db仍然残留之前的信息，尤其是db的t_tray表格

由于ZK中仍然保留旧的 /pureflash/cluster1/stores/1节点信息，pfconductor启动后会读取该节点信息，

修改：
在pfconductor中watch该 /pureflash/cluster1/stores/1节点，一旦发现节点被删除，就清理db中t_tray、t_port、t_store对应信息

在pfstore启动后，
直接删除zk中/pureflash/cluster1/stores/1节点，由pfconductor清理stores/1的旧信息，清理db中t_tray、t_port、t_store对应信息
重新在zk创建/pureflash/cluster1/stores/1节点，由pfconductor获取stores/1的新信息，新建db中t_tray、t_port、t_store对应信息

特别说明：
pfconductor在先启动后，zk中还留有之前pfstore的store id的注册信息，按照正常流程，会读取之前的信息，并且，会watchNewChild节点/pureflash/cluster1/stores/1/trays，以便于发现新增的tray（硬盘）。

但是，后面pfstore启动后，会删除zk中之前的节点/pureflash/cluster1/stores/1、/pureflash/cluster1/stores/1/trays，这便导致pfconductor在watch ZK中的节点/pureflash/cluster1/stores/1/trays时候，出现失败。此处watchNewChild出错处理，修改为与watchNode类似，仅仅日志体现错误。

此处修改与pfstore同步，具体可见https://github.com/cocalele/PureFlash/pull/110